### PR TITLE
Update Framework description from OSGi core R7 to R8 on subproject summary page

### DIFF
--- a/modules/ROOT/pages/subprojects.adoc
+++ b/modules/ROOT/pages/subprojects.adoc
@@ -43,7 +43,7 @@ If this project is not using Maven, refer to the docs for the subproject on how 
 | https://github.com/apache/felix-dev/tree/master/fileinstall[source]
 
 | xref:subprojects/apache-felix-framework.adoc[Framework]
-| An implementation of the OSGi R7 core framework.
+| An implementation of the OSGi R8 core framework.
 | https://github.com/apache/felix-dev/tree/master/framework[source]
 
 | xref:subprojects/apache-felix-framework-security.adoc[Framework Security]


### PR DESCRIPTION
According to https://felix.apache.org/documentation/subprojects/apache-felix-framework.html, Apache Felix Framework implements OSGi core R8 but in the subproject summary page, it mentions R7.