### PR TITLE
Update index.adoc for a broken link

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 =  Welcome to Apache Felix
 
-Apache Felix is a community effort to implement the http://www.osgi.org/Specifications/HomePage[OSGi Framework and Service platform] and other interesting OSGi-related technologies under the Apache license.
+Apache Felix is a community effort to implement the https://docs.osgi.org/specification/[OSGi Framework and Service platform] and other interesting OSGi-related technologies under the Apache license.
 The OSGi specifications originally targeted embedded devices and home services gateways, but they are ideally suited for any project interested in the principles of modularity, component-orientation, and/or service-orientation.
 OSGi technology combines aspects of these aforementioned principles to define a dynamic service deployment framework that is amenable to remote management.
 


### PR DESCRIPTION
Update the broken link to the OSGi Specifications page at https://docs.osgi.org/specification/