### PR TITLE
Pending HTTP release

### DIFF
--- a/downloads.list
+++ b/downloads.list
@@ -55,10 +55,10 @@ Health Check API|org.apache.felix.healthcheck.api|2.0.4|project||-
 Health Check Core|org.apache.felix.healthcheck.core|2.2.0|project||-
 Health Check General Checks|org.apache.felix.healthcheck.generalchecks|3.0.8|project||-
 Health Check Webconsole Plugin|org.apache.felix.healthcheck.webconsoleplugin|2.2.0|project||-
-HTTP Service Base|org.apache.felix.http.base|5.1.8
+HTTP Service Base|org.apache.felix.http.base|5.1.10
 HTTP Service Bridge|org.apache.felix.http.bridge|5.1.8
-HTTP Service Jetty|org.apache.felix.http.jetty|5.1.26
-HTTP Service Jetty|org.apache.felix.http.jetty12|1.0.19
+HTTP Service Jetty|org.apache.felix.http.jetty|5.1.28
+HTTP Service Jetty|org.apache.felix.http.jetty12|1.0.20
 HTTP Service Proxy|org.apache.felix.http.proxy|3.0.6
 HTTP Service SSL filter|org.apache.felix.http.sslfilter|2.0.2
 HTTP Service Whiteboard|org.apache.felix.http.whiteboard|4.0.0

--- a/modules/ROOT/examples/downloads.yml
+++ b/modules/ROOT/examples/downloads.yml
@@ -173,7 +173,7 @@ subprojects:
 
   - title: HTTP Service Base
     artifactId: org.apache.felix.http.base
-    version: 5.1.8
+    version: 5.1.10
     source_classifier: source-release
     changelog: false
 
@@ -185,13 +185,13 @@ subprojects:
 
   - title: HTTP Service Jetty
     artifactId: org.apache.felix.http.jetty
-    version: 5.1.26
+    version: 5.1.28
     source_classifier: source-release
     changelog: false
 
   - title: HTTP Service Jetty12
     artifactId: org.apache.felix.http.jetty12
-    version: 1.0.19
+    version: 1.0.20
     source_classifier: source-release
     changelog: false
 

--- a/modules/ROOT/pages/news.adoc
+++ b/modules/ROOT/pages/news.adoc
@@ -5,6 +5,7 @@
 * Apache Felix Http Jetty12 1.0.20, Http Jetty 5.1.28 (January 22 2025)
 ** https://issues.apache.org/jira/browse/FELIX-6746 JettyWebSocketServlet: Error during calling init()
 ** https://issues.apache.org/jira/browse/FELIX-6745 HttpService: Cannot unregister javaxwrappers.ServletWrapper
+** https://issues.apache.org/jira/browse/FELIX-6720 Enable virtual thread support in jetty12
 
 
 ## 2024

--- a/modules/ROOT/pages/news.adoc
+++ b/modules/ROOT/pages/news.adoc
@@ -1,5 +1,13 @@
 = News
 
+## 2025
+
+* Apache Felix Http Jetty12 1.0.20, Http Jetty 5.1.28 (January 22 2025)
+** https://issues.apache.org/jira/browse/FELIX-6746 JettyWebSocketServlet: Error during calling init()
+** https://issues.apache.org/jira/browse/FELIX-6745 HttpService: Cannot unregister javaxwrappers.ServletWrapper
+
+
+## 2024
 * Apache Felix Http Jetty12 1.0.19 (December 16th 2024)
 * Apache Felix Maven Bundle Plugin 6.0.0 (November 28th, 2024)
 * Apache Felix Http Jetty12 1.0.18, Http Jetty 4.2.28 and Http Wrapper 1.1.8 (November 17th 2024)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FELIX-6746 JettyWebSocketServlet: Error during calling init()
https://issues.apache.org/jira/browse/FELIX-6745 HttpService: Cannot unregister javaxwrappers.ServletWrapper
https://issues.apache.org/jira/browse/FELIX-6720 Enable virtual thread support in jetty12