### PR TITLE
Release Apache Felix Http Jetty 4.2.32, Http Jetty 5.2.0, Http Jetty12 1.1.0, HTTP Bridge 6.1.0

### DIFF
--- a/downloads.list
+++ b/downloads.list
@@ -56,9 +56,9 @@ Health Check Core|org.apache.felix.healthcheck.core|2.3.0|project||-
 Health Check General Checks|org.apache.felix.healthcheck.generalchecks|3.0.8|project||-
 Health Check Webconsole Plugin|org.apache.felix.healthcheck.webconsoleplugin|2.2.0|project||-
 HTTP Service Base|org.apache.felix.http.base|5.1.16
-HTTP Service Bridge|org.apache.felix.http.bridge|6.0.0
-HTTP Service Jetty|org.apache.felix.http.jetty|5.1.34
-HTTP Service Jetty|org.apache.felix.http.jetty12|1.0.36
+HTTP Service Bridge|org.apache.felix.http.bridge|6.1.0
+HTTP Service Jetty|org.apache.felix.http.jetty|5.2.0
+HTTP Service Jetty|org.apache.felix.http.jetty12|1.1.0
 HTTP Service Proxy|org.apache.felix.http.proxy|3.0.6
 HTTP Service SSL filter|org.apache.felix.http.sslfilter|2.0.2
 HTTP Service Whiteboard|org.apache.felix.http.whiteboard|4.0.0

--- a/modules/ROOT/examples/downloads.yml
+++ b/modules/ROOT/examples/downloads.yml
@@ -179,19 +179,19 @@ subprojects:
 
   - title: HTTP Service Bridge
     artifactId: org.apache.felix.http.bridge
-    version: 6.0.0
+    version: 6.1.0
     source_classifier: source-release
     changelog: false
 
   - title: HTTP Service Jetty
     artifactId: org.apache.felix.http.jetty
-    version: 5.1.34
+    version: 5.2.0
     source_classifier: source-release
     changelog: false
 
   - title: HTTP Service Jetty12
     artifactId: org.apache.felix.http.jetty12
-    version: 1.0.36
+    version: 1.1.0
     source_classifier: source-release
     changelog: false
 

--- a/modules/ROOT/pages/news.adoc
+++ b/modules/ROOT/pages/news.adoc
@@ -2,6 +2,12 @@
 
 ## 2025
 
+* Apache Felix Http Jetty 4.2.32, Http Jetty 5.2.0, Http Jetty12 1.1.0, HTTP Bridge 6.1.0 (August 25th, 2025)
+** https://issues.apache.org/jira/browse/FELIX-6792 Do not embed Apache Commons IO and FIleupload
+** https://issues.apache.org/jira/browse/FELIX-6797 Update to Jetty 11.0.26 / 12.0.25 / 9.4.58.v20250814
+* Apache Felix Http Base 5.1.16 (June 8th, 2025)
+* Apache Felix Http Jetty12 1.0.34 (June 6th, 2025)
+* Apache Felix Http Jetty12 1.0.32
 * Apache Felix Http Jetty12 1.0.36 (July 21th, 2025)
 ** https://issues.apache.org/jira/browse/FELIX-6790 Update to Jetty 12.0.23
 * Apache Felix Http Base 5.1.16 (June 8th, 2025)


### PR DESCRIPTION
Release Apache Felix Http Jetty 4.2.32, Http Jetty 5.2.0, Http Jetty12 1.1.0, HTTP Bridge 6.1.0