### PR TITLE
Http Jetty12 1.2.0 (EE10)

### DIFF
--- a/downloads.list
+++ b/downloads.list
@@ -58,7 +58,7 @@ Health Check Webconsole Plugin|org.apache.felix.healthcheck.webconsoleplugin|2.2
 HTTP Service Base|org.apache.felix.http.base|5.1.18
 HTTP Service Bridge|org.apache.felix.http.bridge|6.1.2
 HTTP Service Jetty|org.apache.felix.http.jetty|5.2.2
-HTTP Service Jetty|org.apache.felix.http.jetty12|2.0.0
+HTTP Service Jetty (EE11)|org.apache.felix.http.jetty12|2.0.0
 HTTP Service Jetty (EE10)|org.apache.felix.http.jetty12|1.2.0
 HTTP Service Proxy|org.apache.felix.http.proxy|3.0.6
 HTTP Service SSL filter|org.apache.felix.http.sslfilter|2.0.2

--- a/downloads.list
+++ b/downloads.list
@@ -59,6 +59,7 @@ HTTP Service Base|org.apache.felix.http.base|5.1.18
 HTTP Service Bridge|org.apache.felix.http.bridge|6.1.2
 HTTP Service Jetty|org.apache.felix.http.jetty|5.2.2
 HTTP Service Jetty|org.apache.felix.http.jetty12|2.0.0
+HTTP Service Jetty (EE10)|org.apache.felix.http.jetty12|1.2.0
 HTTP Service Proxy|org.apache.felix.http.proxy|3.0.6
 HTTP Service SSL filter|org.apache.felix.http.sslfilter|2.0.2
 HTTP Service Whiteboard|org.apache.felix.http.whiteboard|4.0.0

--- a/modules/ROOT/examples/downloads.yml
+++ b/modules/ROOT/examples/downloads.yml
@@ -189,7 +189,7 @@ subprojects:
     source_classifier: source-release
     changelog: false
 
-  - title: HTTP Service Jetty12
+  - title: HTTP Service Jetty12 (EE11)
     artifactId: org.apache.felix.http.jetty12
     version: 2.0.0
     source_classifier: source-release

--- a/modules/ROOT/examples/downloads.yml
+++ b/modules/ROOT/examples/downloads.yml
@@ -195,6 +195,12 @@ subprojects:
     source_classifier: source-release
     changelog: false
 
+  - title: HTTP Service Jetty12 (EE10)
+    artifactId: org.apache.felix.http.jetty12
+    version: 1.2.0
+    source_classifier: source-release
+    changelog: false
+
   - title: HTTP Service Proxy
     artifactId: org.apache.felix.http.proxy
     version: 4.0.0

--- a/modules/ROOT/pages/news.adoc
+++ b/modules/ROOT/pages/news.adoc
@@ -1,6 +1,8 @@
 = News
 
 ## 2026
+* Apache Felix Http Jetty12 1.2.0 (June 2nd, 2026)
+** https://issues.apache.org/jira/browse/FELIX-6831 Offer a EE10 compatible Jetty12 bundle with Jetty 12.1.x
 * Apache Felix Http Jetty12 2.0.0 (June 1st, 2026)
 ** https://issues.apache.org/jira/browse/FELIX-6750 Try out Jetty 12.1.0 in Felix HTTP (major upgrade to Jetty 12.1.9, first EE11 compatible HTTP implementation)
 * Apache Felix Http base 5.1.18, Http Jetty 5.2.2, Http Jetty12 1.1.10 (May 22nd, 2026)


### PR DESCRIPTION
## Summary
EE10 counterpart of the Http Jetty12 2.0.0 release. Still based on Jetty 12.1.9, but built with EE10 artifacts instead of EE11. This line is maintained in https://github.com/apache/felix-dev/tree/http.jetty12.ee10 going forward.

Resolved issue:
* https://issues.apache.org/jira/browse/FELIX-6831 — Offer a EE10 compatible Jetty12 bundle with Jetty 12.1.x

## Changes
* `news.adoc` — add 1.2.0 (EE10) entry
* `downloads.list` / `downloads.yml` — add a separate "HTTP Service Jetty12 (EE10)" entry at 1.2.0 alongside the existing 2.0.0 (EE11) entry

## Staging
https://repository.apache.org/content/repositories/orgapachefelix-1546

Verify with:
```
sh check_staged_release.sh 1546 /tmp/felix-staging
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)